### PR TITLE
text-block.renderer: open link in new tab

### DIFF
--- a/packages/client/src/blocks/text-block.renderer.ts
+++ b/packages/client/src/blocks/text-block.renderer.ts
@@ -9,7 +9,7 @@ export default createBlockRenderer<TextRichTextItemResponse>(
     let result = sanitizeHtml(data.plain_text);
 
     if (data.href) {
-      result = `<a href="${data.href}" class="notion-text-href">${result}</a>`;
+      result = `<a href="${data.href}" class="notion-text-href" target="_blank" rel="noopener nofollow">${result}</a>`;
     }
 
     if (data.annotations.color !== 'default') {


### PR DESCRIPTION
usually links in blog posts should open in a new tab.

we could also add a config maybe?

or we could check it the link is going to the same domain? => to not add _blank